### PR TITLE
Add support for MQTT broker authentication

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,8 @@
 mqtt:
     broker: 192.168.34.118
     port: 1883
+#    username: ""
+#    password: ""
 
 waves:
   - name: "basement-radon"

--- a/src/airthingswave-mqtt/airthingswave.py
+++ b/src/airthingswave-mqtt/airthingswave.py
@@ -75,6 +75,8 @@ class AirthingsWave_mqtt:
 
     def mqtt_connect(self, conf):
         self.mqtt_conf=self.config["mqtt"]
+        if self.mqtt_conf["username"] is not None:
+            self.mqtt_client.username_pw_set(self.mqtt_conf["username"], self.mqtt_conf["password"])
         self.mqtt_client.connect(self.mqtt_conf["broker"], self.mqtt_conf["port"])
 
     def ble_connect(self, addr):


### PR DESCRIPTION
Hey @hpeyerl, I've been using your Airthings Wave bridge on a Pi Zero W for the last couple of months; it works great and is rock solid! 👍 

This simple PR adds basic support for MQTT broker authentication. Feel free to edit it as you see fit. 😃