### PR TITLE
Add support for PyYAML SafeLoader

### DIFF
--- a/src/airthingswave-mqtt/airthingswave.py
+++ b/src/airthingswave-mqtt/airthingswave.py
@@ -45,7 +45,7 @@ class Sensor:
 class AirthingsWave_mqtt:
     def __init__(self, config_file):
         with open(config_file, 'r') as f:
-            self.config = yaml.load(f)
+            self.config = yaml.load(f, Loader=yaml.SafeLoader)
         self.waves = list()
         if self.check_config(self.config):
             self.mqtt_client = mqtt.Client()


### PR DESCRIPTION
PyYAML 5.1+ is now warning about not using loaders when feeding it a resource:
https://msg.pyyaml.org/load

Since [SafeLoader is available in PyYAML 3.*](https://github.com/yaml/pyyaml/blob/3.01/lib/yaml/loader.py), this PR simply adds support for it.

Tested using Python 2.7 and 3.5.
