### PR TITLE
Fix type handling issue on Python 3

### DIFF
--- a/src/airthingswave-mqtt/airthingswave.py
+++ b/src/airthingswave-mqtt/airthingswave.py
@@ -80,7 +80,7 @@ class AirthingsWave_mqtt:
         self.mqtt_conf = conf["mqtt"]
         if self.mqtt_conf["username"]:
             self.mqtt_client.username_pw_set(self.mqtt_conf["username"], self.mqtt_conf["password"])
-        self.mqtt_client.connect(self.mqtt_conf["broker"], self.mqtt_conf["port"])
+        self.mqtt_client.connect(self.mqtt_conf["broker"], int(self.mqtt_conf["port"]))
 
     def mqtt_disconnect(self):
         self.mqtt_client.disconnect()


### PR DESCRIPTION
When testing the library on Python 3.5, Paho complains about a mismatching type for the client port. 

```text
Config file: /usr/src/app/airthingswave-mqtt.yaml
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/lib/python3.5/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.5/site-packages/airthingswave-mqtt/__main__.py", line 36, in <module>
    main()
  File "/usr/local/lib/python3.5/site-packages/airthingswave-mqtt/__main__.py", line 18, in main
    atw = airthingswave.AirthingsWave_mqtt(c)
  File "/usr/local/lib/python3.5/site-packages/airthingswave-mqtt/airthingswave.py", line 52, in __init__
    self.mqtt_connect(self.config)
  File "/usr/local/lib/python3.5/site-packages/airthingswave-mqtt/airthingswave.py", line 83, in mqtt_connect
    self.mqtt_client.connect(self.mqtt_conf["broker"], self.mqtt_conf["port"])
  File "/usr/local/lib/python3.5/site-packages/paho/mqtt/client.py", line 838, in connect
    self.connect_async(host, port, keepalive, bind_address)
  File "/usr/local/lib/python3.5/site-packages/paho/mqtt/client.py", line 894, in connect_async
    if port <= 0:
TypeError: unorderable types: str() <= int()
```

See Paho port validation: https://github.com/eclipse/paho.mqtt.python/blob/a8b2b4d039571e9bd873dd550a1dddabc6d3cb61/src/paho/mqtt/client.py#L936

This quick PR aims to fix this by casting the configuration port to integer.

Tested on both Python 2.7 and 3.5