### PR TITLE
add support for v2 devices

### DIFF
--- a/src/airthingswave-mqtt/__main__.py
+++ b/src/airthingswave-mqtt/__main__.py
@@ -22,9 +22,7 @@ def main():
         i = 0
         while i < count:
             print(atw.waves[i]["name"], atw.waves[i]["addr"])
-            handle = atw.ble_connect(atw.waves[i]["addr"])
-            r = atw.get_readings(handle)
-            atw.ble_disconnect(handle)
+            r = atw.get_readings(i)
             print("{0} says Date: {1} Temp: {2} Humidity: {3} 24H: {4} Long term: {5}".format(atw.waves[i]["name"], r["DateTime"], r["Temperature"], r["Humidity"], r["Radon-Day"], r["Radon-Long-Term"], ))
             atw.publish_readings(atw.waves[i]["name"], r)
             i = i+1


### PR DESCRIPTION
Your airthingswave-mqtt repo was the perfect fit for my use case:
- home assistant on a computer (VM) with no bluetooth
- available raspberry pi
- airthings wave radon detector getting little attention because I didn't buy their hub and their mobile app is very flaky.

Unfortunately, I have a v2 wave. These tweaks got your code working with my v2 device (I don't have a v1 device to verify I didn't break anything). There were three main changes:
- Added an optional "version" attribute to each wave device in the config file.
- The v2 device reads all sensor data in a single bluetooth characteristic (UUID).
- Since `get_readings()` only took the BT connection handle, it didn't know which wave it was reading from (and hence didn't know whether it was a v1 or v2 device). So I pulled the BT connection code into `get_readings()` and instead passed in the device index.

I only made the changes I needed (and I copied my changed files into an existing pip install of your package in a virtual environment), so there may be impacts elsewhere in the repo (e.g. README). If you want to take these changes, and feel like this needs more work, I may be able to invest a little more effort (either dev or v2 testing).

Also, I got this running hourly on my raspberry pi with systemd service and timer units. I could write up a description of how I did that - maybe in the wiki?